### PR TITLE
Fix icegrid Make and configurations for Ice 3.7

### DIFF
--- a/cpp/Server-icegrid.config
+++ b/cpp/Server-icegrid.config
@@ -1,0 +1,4 @@
+PrinterAdapter.Endpoints=tcp
+PrinterAdapter.AdapterId=PrinterAdapter1
+PrinterAdapter.Locator=IceGrid/Locator -t:tcp -h 127.0.0.1 -p 9999
+Ice.IPv6=0

--- a/icegrid/Makefile
+++ b/icegrid/Makefile
@@ -6,14 +6,14 @@ NODE_DIRS=$(addprefix /tmp/db/, $(NODES))
 IG_ADMIN=icegridadmin --Ice.Config=locator.config -u user -p pass
 
 start-grid: /tmp/db/registry $(NODE_DIRS)
-	icegridnode --Ice.Config=node1.config &
+	icegridregistry --Ice.Config=registry.config &
 
 	@echo -- waiting registry to start...
 	@while ! netstat -lptn 2> /dev/null | grep ":4061" > /dev/null; do \
 	    sleep 1; \
 	done
 
-	@for node in $(filter-out node1, $(NODES)); do \
+	@for node in $(NODES); do \
 	    icegridnode --Ice.Config=$$node.config & \
 	    echo -- $$node started; \
 	done
@@ -26,6 +26,7 @@ stop-grid:
 	done
 
 	@killall icegridnode
+	@killall icegridregistry
 	@echo -- ok
 
 show-nodes:

--- a/icegrid/node1.config
+++ b/icegrid/node1.config
@@ -2,14 +2,6 @@ Ice.Default.Locator=IceGrid/Locator -t:tcp -h 127.0.0.1 -p 4061
 IceGrid.Node.Name=node1
 IceGrid.Node.Data=/tmp/db/node1
 IceGrid.Node.Endpoints=tcp
-IceGrid.Node.CollocateRegistry=1
-IceGrid.Registry.Client.Endpoints=tcp -p 4061
-IceGrid.Registry.Server.Endpoints=tcp
-IceGrid.Registry.Internal.Endpoints=tcp
-IceGrid.Registry.LMDB.Path=/tmp/db/registry
-IceGrid.Registry.PermissionsVerifier=IceGrid/NullPermissionsVerifier
-IceGrid.Registry.AdminPermissionsVerifier=IceGrid/NullPermissionsVerifier
-IceGrid.Registry.DefaultTemplates=/usr/share/ice/templates.xml
 
 # Ice.StdOut=/tmp/db/node1/out.txt
 # Ice.StdErr=/tmp/db/node1/err.txt

--- a/icegrid/node3.config
+++ b/icegrid/node3.config
@@ -1,7 +1,0 @@
-Ice.Default.Locator=IceGrid/Locator -t:tcp -h 127.0.0.1 -p 4061
-IceGrid.Node.Name=node3
-IceGrid.Node.Data=/tmp/db/node3
-IceGrid.Node.Endpoints=tcp
-
-# Ice.StdOut=/tmp/db/node3/out.txt
-# Ice.StdErr=/tmp/db/node3/err.txt

--- a/icegrid/registry.config
+++ b/icegrid/registry.config
@@ -1,0 +1,11 @@
+IceGrid.Registry.Client.Endpoints=tcp -p 4061
+IceGrid.Registry.Server.Endpoints=tcp
+IceGrid.Registry.Internal.Endpoints=tcp
+IceGrid.Registry.LMDB.Path=/tmp/db/registry
+
+IceGrid.Registry.PermissionsVerifier=IceGrid/NullPermissionsVerifier
+IceGrid.Registry.AdminPermissionsVerifier=IceGrid/NullPermissionsVerifier
+IceGrid.Registry.DefaultTemplates=/usr/share/ice/templates.xml
+
+IceGrid.Registry.DynamicRegistration=1
+

--- a/py/Server-icegrid.config
+++ b/py/Server-icegrid.config
@@ -1,0 +1,1 @@
+../cpp/Server-icegrid.config


### PR DESCRIPTION
Tested on 2021-11-17

- Now the registry is run with a separated binary (`icegridregistry`) instead using `icegridnode`.
- Removed one of the nodes because now `node1` is exactly the same as `node2` and the removed `node3`.
- Adapted the `Makefile` to use the same rules as before
- Added a new configuration file for the "hello world" servers that register the object adapter in the registry